### PR TITLE
feat: support coloring for cargo tools

### DIFF
--- a/.changeset/thin-turtles-protect.md
+++ b/.changeset/thin-turtles-protect.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+feat: support coloring for cargo tools

--- a/src/utils/proc_manager.ts
+++ b/src/utils/proc_manager.ts
@@ -204,11 +204,13 @@ export const createProcManager = ({ forceNoColor }: CreateProcManagerParams): Pr
               npm_config_color: 'always',
               NO_COLOR: undefined,
               FORCE_COLOR: 'true',
+              CARGO_TERM_COLOR: 'always',
             }
           : {
               npm_config_color: 'false',
               NO_COLOR: 'true',
               FORCE_COLOR: '0',
+              CARGO_TERM_COLOR: 'none',
             }),
         [envVarNames.rootToken]: rootNode.token,
         [envVarNames.parentToken]: node.token,


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/config.html#termcolor

無限に増やすのかと言われると難しい。こういうのをまとめた npm package とかあればそちら使うのを検討したい。
基本的にはユーザーに `"notios": "cross-env FOO_COLOR=true notios"` という script を作ってもらうのが正攻法。